### PR TITLE
Remove missing /pages/ references for SEO

### DIFF
--- a/index.html
+++ b/index.html
@@ -127,9 +127,7 @@ _gaq.push(['_trackPageview']);
         <h1><span>&nbsp;</span>SitePoint Christmas Sale</h1>
         <button id="toggle-animations"><span>Animations</span></button>
         <button id="share-to-facebook"><span>Like</span></button>
-        <a id="discuss" class="fancybox fancybox.ajax" href="/pages/faqs.html"><span>Discuss</span></a>
         <button id="share-to-twitter"><span>Tweet</span></button>
-        <a id="faqs" class="fancybox fancybox.ajax" href="/pages/faqs.html"><span>Help/FAQs</span></a>
         <a class="podlings" href="" target="_blank"><span>PODLING</span></a>
     </header>
 
@@ -183,7 +181,7 @@ _gaq.push(['_trackPageview']);
                 <h2>Buy Now!</h2>
                 <form id="checkout-form" action="#" method="POST" target="_blank">
                     <div class="inputs-container"></div>
-                    <p class="hamper-line">With every purchase, you get a <strong>FREE</strong> <a class="fancybox fancybox.ajax" href="/pages/hamper.php">Bonus Coupon Hamper</a>!</p>
+                    <p class="hamper-line">With every purchase, you get a <strong>FREE</strong> Bonus Coupon Hamper!</p>
                     <p><input type="submit" id="buy-button" value="Buy now!" /></p>
                     <p><a class="current-deal"></a></p>
                     <input type="hidden" name="current-day" id="current-day-hidden">

--- a/js/sale_framework.js
+++ b/js/sale_framework.js
@@ -863,7 +863,7 @@ var Bundle_Deal_View = Base_Sale_View.extend({
 			this.hamper_line.html(freebie_html);
 		}
 		else {
-			this.hamper_line.html("With every purchase, you get a <strong>FREE</strong> <a class='fancybox fancybox.ajax' href='/pages/hamper.php'>Bonus Coupon Hamper</a>!")
+			this.hamper_line.html("With every purchase, you get a <strong>FREE</strong> Bonus Coupon Hamper!")
 		}
 	},
 	render_checkout: function() {


### PR DESCRIPTION
This removes broken references to `/pages/faqs.html` and `/pages/hamper.php`, which were apparently both example URLs that have never existed, but do have an SEO impact.

You can see such references going way back to the git initial import, where the associated pages were still absent.