### PR TITLE
Fix duplicate h1 and page title for seo

### DIFF
--- a/story/css/index.html
+++ b/story/css/index.html
@@ -21,7 +21,7 @@
   </head>
   <body>
     <div id="pagetitle">
-      <h1>Sitepoint Christmas Sale - CSS</h1>
+      <h1>Sitepoint Christmas Sale</h1>
     </div>
     <script>
       window.location.replace('https://xmas.sitepoint.com');


### PR DESCRIPTION
Update page `h1` text to fix duplicate title page and h1

No Card

<img width="1162" alt="Screen Shot 2021-04-28 at 10 22 48 AM" src="https://user-images.githubusercontent.com/12265025/116336753-b0d83c80-a80b-11eb-8e80-90d61861461d.png">
